### PR TITLE
remove Addresses and creditCardNo from base data model and add by plugin

### DIFF
--- a/db/schema.cds
+++ b/db/schema.cds
@@ -11,16 +11,7 @@ entity Customers : cuid, managed {
   lastName      : String;
   email         : EMailAddress;
   phone         : PhoneNumber;
-  creditCardNo  : String(16) @assert.format: '^[1-9]\d{15}$';
-  addresses     : Composition of many Addresses on addresses.customer = $self;
   incidents     : Association to many Incidents on incidents.customer = $self;
-}
-
-entity Addresses : cuid, managed {
-  customer      : Association to Customers;
-  city          : City;
-  postCode      : String;
-  streetAddress : String;
 }
 
 /**

--- a/db/schema.cds
+++ b/db/schema.cds
@@ -54,4 +54,3 @@ entity Conversations : cuid, managed {
 
 type EMailAddress : String;
 type PhoneNumber  : String;
-type City         : String;


### PR DESCRIPTION
- As discussed, the base data model should not include addresses
- Audit-log or other plugins should extend the base data model in `samples`
- This extension is done [here](https://github.com/cap-js/calesi/tree/rm-address-base-data-model)