### PR TITLE
Add @Common.Labels for Incidents, Conversations

### DIFF
--- a/_i18n/i18n.properties
+++ b/_i18n/i18n.properties
@@ -1,3 +1,5 @@
+Incidents=Incidents
+Customers=Customers
 
 #XFLD,120: Label for a filter field
 Urgency=Urgency

--- a/app/incidents/annotations.cds
+++ b/app/incidents/annotations.cds
@@ -75,6 +75,10 @@ annotate service.Incidents with @(
         status_code,
     ]
 );
+
+annotate  sap.capire.incidents.Incidents with @Common.Label: '{i18n>Incidents}';
+annotate  sap.capire.incidents.Conversations with @Common.Label: '{i18n>Conversations}';
+
 annotate service.Incidents with {
     status @Common.Label : '{i18n>Status}'
 };


### PR DESCRIPTION
- `@Common.Label` is used by [`@cap-js/change-tracking`](https://github.com/cap-js/change-tracking) to make the last column **Object Type** (tntity type) *human readable*, from this...
   <img width="1175" alt="Screenshot 2023-10-13 at 14 33 20" src="https://github.com/cap-js/incidents-app/assets/8320933/c3e8f59f-5bf2-4d92-b888-8fc737679698">
...to this:
   <img width="1175" alt="Screenshot 2023-10-13 at 14 32 35" src="https://github.com/cap-js/incidents-app/assets/8320933/45add7c1-545a-4c75-849f-45e58524eba9">

- Note, that this is analogous to the property **Field** for elements, which uses `@Common.Label` to make it *human readable*