### PR TITLE
Update to SAPUI5 v1.120.0

### DIFF
--- a/app/incidents/README.md
+++ b/app/incidents/README.md
@@ -12,7 +12,7 @@
 |**Application Title**<br>Incident-Management|
 |**Namespace**<br>ns|
 |**UI5 Theme**<br>sap_horizon|
-|**UI5 Version**<br>1.115.0|
+|**UI5 Version**<br>1.120.0|
 |**Enable Code Assist Libraries**<br>False|
 |**Enable TypeScript**<br>False|
 |**Add Eslint configuration**<br>False|

--- a/app/incidents/webapp/index.html
+++ b/app/incidents/webapp/index.html
@@ -12,7 +12,7 @@
     </style>
     <script
         id="sap-ui-bootstrap"
-        src="https://sapui5.hana.ondemand.com/1.115.0/resources/sap-ui-core.js"
+        src="https://sapui5.hana.ondemand.com/1.120.0/resources/sap-ui-core.js"
         data-sap-ui-theme="sap_horizon"
         data-sap-ui-resourceroots='{
             "ns.incidents": "./"

--- a/app/incidents/webapp/manifest.json
+++ b/app/incidents/webapp/manifest.json
@@ -58,7 +58,7 @@
     "sap.ui5": {
         "flexEnabled": true,
         "dependencies": {
-            "minUI5Version": "1.115.0",
+            "minUI5Version": "1.120.0",
             "libs": {
                 "sap.m": {},
                 "sap.ui.core": {},

--- a/app/incidents/webapp/test/flpSandbox.html
+++ b/app/incidents/webapp/test/flpSandbox.html
@@ -54,10 +54,10 @@
         };
     </script>
 
-    <script src="https://sapui5.hana.ondemand.com/1.115.0/test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
+    <script src="https://sapui5.hana.ondemand.com/1.120.0/test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
     <!-- Bootstrap the UI5 core library -->
     <script id="sap-ui-bootstrap"
-        src="https://sapui5.hana.ondemand.com/1.115.0/resources/sap-ui-core.js"
+        src="https://sapui5.hana.ondemand.com/1.120.0/resources/sap-ui-core.js"
         data-sap-ui-libs=""
         data-sap-ui-async="true"
         data-sap-ui-preload="async"


### PR DESCRIPTION
- [SAPUI5 v1.120.0](https://sapui5.hana.ondemand.com/1.120.0/versioninfo.html) is out, which includes fixes for lazy loading of smart tables
- Want to [use lazy loading in @cap-js/change-tracking](https://github.com/cap-js/change-tracking/pull/42)