### PR TITLE
delete draft before deleting incident

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -118,6 +118,11 @@ describe('Draft Choreography APIs', () => {
     })
   })
 
+  it('- Delete the Draft', async () => {
+    const response = await DELETE(`/odata/v4/processor/Incidents(ID=${draftId},IsActiveEntity=false)`)
+    expect(response.status).to.eql(204)
+  })
+
   it('- Delete the Incident', async () => {
     const response = await DELETE(`/odata/v4/processor/Incidents(ID=${draftId},IsActiveEntity=true)`)
     expect(response.status).to.eql(204)


### PR DESCRIPTION
Change in node runtime disallows to delete an entity with an active draft.
Hence, adding a test to delete the draft before deleting the entity.