### PR TITLE
Splitting Roles

### DIFF
--- a/srv/services.cds
+++ b/srv/services.cds
@@ -9,9 +9,8 @@ service ProcessorService @(requires:'support') {
 }
 
 /**
- * Service used by administrators to manage customers and incidents.
+ * Service used by administrators to manage customers.
  */
 service AdminService @(requires:'admin') {
   entity Customers as projection on my.Customers;
-  entity Incidents as projection on my.Incidents;
 }


### PR DESCRIPTION
In this PR i have isolated the admin and support role.
This gives ability to choose if the admin can process the incidents or not. If the admin  need to process incidents, support role can be assigned separately.