### PR TITLE
UI Annotations updated

### DIFF
--- a/app/incidents/annotations.cds
+++ b/app/incidents/annotations.cds
@@ -1,6 +1,7 @@
 using ProcessorService as service from '../../srv/processor-service';
 using from '../../db/schema';
 annotate service.Incidents with @(
+    Common.SemanticKey: [title],
     UI.FieldGroup #GeneratedGroup : {
         $Type : 'UI.FieldGroupType',
         Data : [
@@ -32,35 +33,36 @@ annotate service.Incidents with @(
                     Label : '{i18n>Details}',
                     ID : 'i18nDetails',
                     Target : '@UI.FieldGroup#i18nDetails',
-                },
-                {
-                    $Type : 'UI.ReferenceFacet',
-                    Label : '{i18n>Conversation}',
-                    ID : 'i18nConversation',
-                    Target : 'conversation/@UI.LineItem#i18nConversation',
                 },],
+        },
+        {
+            $Type : 'UI.ReferenceFacet',
+            Label : '{i18n>Conversation}',
+            ID : 'i18nConversation',
+            Target : 'conversation/@UI.LineItem#i18nConversation',
         },
     ],
     UI.LineItem : [
         {
             $Type : 'UI.DataField',
             Value : title,
+            Label : '{i18n>Title}',
         },
         {
             $Type : 'UI.DataField',
-            Value : customer.name,
             Label : '{i18n>Customer}',
+            Value : customer_ID,
         },
         {
             $Type : 'UI.DataField',
-            Value : status.descr,
             Label : '{i18n>Status}',
+            Value : status_code,
             Criticality : status.criticality,
         },
         {
             $Type : 'UI.DataField',
-            Value : urgency.descr,
             Label : '{i18n>Urgency}',
+            Value : urgency_code,
         },
     ],
 );
@@ -100,10 +102,40 @@ annotate service.Incidents with {
     urgency @Common.Label : '{i18n>Urgency}'
 };
 annotate service.Incidents with {
+    status @Common.ValueListWithFixedValues : true
+};
+annotate service.Status with {
+    code @Common.Text : {
+        $value : descr,
+        ![@UI.TextArrangement] : #TextOnly,
+    }
+};
+annotate service.Incidents with {
     urgency @Common.ValueListWithFixedValues : true
 };
 annotate service.Urgency with {
-    code @Common.Text : descr
+    code @Common.Text : {
+        $value : descr,
+        ![@UI.TextArrangement] : #TextOnly,
+    }
+};
+annotate service.Incidents with {
+    status @Common.Text : {
+            $value : status.descr,
+            ![@UI.TextArrangement] : #TextOnly,
+        }
+};
+annotate service.Incidents with {
+    urgency @Common.Text : {
+            $value : urgency.descr,
+            ![@UI.TextArrangement] : #TextOnly,
+        }
+};
+annotate service.Incidents with {
+    customer @Common.Text : {
+            $value : customer.name,
+            ![@UI.TextArrangement] : #TextOnly,
+        }
 };
 annotate service.Incidents with @(
     UI.HeaderInfo : {
@@ -134,25 +166,7 @@ annotate service.Incidents with @(
     }
 );
 annotate service.Incidents with {
-    customer @Common.Text : {
-            $value : customer.name,
-            ![@UI.TextArrangement] : #TextOnly,
-        }
-};
-annotate service.Incidents with {
     customer @Common.ValueListWithFixedValues : false
-};
-annotate service.Incidents with {
-    status @Common.Text : status.descr
-};
-annotate service.Incidents with {
-    status @Common.ValueListWithFixedValues : true
-};
-annotate service.Status with {
-    code @Common.Text : descr
-};
-annotate service.Incidents with {
-    urgency @Common.Text : urgency.descr
 };
 annotate service.Incidents.conversation with @(
     UI.LineItem #i18nConversation : [


### PR DESCRIPTION
based on the outcome of the FE tutorial review, the UI annotations are slightly updated:
- adding Common.SemanticKey
- adding a missing i18n title
- Moving the conversation facet outside of the collection facet to correspond to the tutorial screenshots
- usage of customer_ID and urgency_code with Common.Text and Common.TextArrangement on the LR lineItem annotation instead of the associated description fields