### PR TITLE
Fix: change tracking delete test case with v1.0.7

### DIFF
--- a/xmpls/change-tracking.test.js
+++ b/xmpls/change-tracking.test.js
@@ -126,8 +126,10 @@ describe("Integration Test for ChangeTracking", () => {
         const incidentChanges = await SELECT.from(ChangeView).where({
                 entity: "sap.capire.incidents.Incidents",
                 attribute: "status",
+                keys: `ID=${draftId}`,
+                modification: "delete"
             })
-        expect(incidentChanges.length).to.equal(0);
+        expect(incidentChanges.length).to.equal(1);
       });
     });
 });


### PR DESCRIPTION
Older implementation resulted in 0 entries in changeView 
https://github.com/cap-js/incidents-app/blob/259abc1e41142f2d2f27d3c8cb09af0ee1e9aed1/xmpls/change-tracking.test.js#L125-L130

With upcoming v1.0.7, there seems to be change and this fix works.

(To be merged after change-tracking v1.0.7 release, as this fails in older version).