### PR TITLE
ci: fix central mbt build

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -141,4 +141,5 @@ build-parameters:
   before-all:
     - builder: custom
       commands:
+        - npm install
         - npx cds build --production


### PR DESCRIPTION
For the mbt build to work `npm install` needs to be called in the `before-all` section. Without that the npx can not be called and the mbt fails. 

Without this fix the build fails in all clean (ci) environments without prior `npm install`.

From the build logs:
```
info  mtaBuild - Executing mta build call: "mbt build --mtar capire.sflight.mtar --platform CF --source ./ --target /home/jenkins/agent/workspace/abc"
```

leads to

```
error mtaBuild - [2024-11-28 12:21:00] ERROR the "before-all"" build failed: could not execute the "npx -p @sap/cds-dk cds build --profile production,node" command: exit status 1
info  mtaBuild - make: *** [Makefile_20241128122054.mta:28: pre_build] Error 1
```