### PR TITLE
Update ams-tests.http

### DIFF
--- a/test/ams-tests.http
+++ b/test/ams-tests.http
@@ -13,8 +13,3 @@ Authorization: Basic alice:wonderland
 GET {{host}}/odata/v4/processor/Incidents
 Authorization: Basic bob:builder
 
-
-### Troubleshooting
-# During `cds w samples/ams`, `@sap/ams-dev` generates DCL from `@restrict`/ `@requires` in *.cds into folder `samples/ams/ams`.
-# If this doesn't happen, your cds-dk may be in a location that `@sap/ams` doesn't expect (fix underway).
-# Temporary workaround: In the repo root, execute `npm i --no-save @sap/cds-dk` and run the sample via `npx cds w samples/ams`.


### PR DESCRIPTION
There is no `samples/ams`(anymore?), so I propose to delete this comment.