### PR TITLE
Fix attachments.test.js

### DIFF
--- a/test/attachments.test.js
+++ b/test/attachments.test.js
@@ -48,9 +48,15 @@ describe('Test attachments service', () => {
     id = `ID=${created.data.ID}` //> captures the newly created Attachments's ID for subsequent use...
 
     // Upload the file
+    const filePath = path.join(cds.root, 'xmpls', 'SolarPanelReport.pdf');
+    const fileSize = require('fs').statSync(filePath).size;
+
     const uploaded = await PUT (`${Incidents}_attachments(up__${ID},${id},${draft})/content`,
-      require('fs').createReadStream (cds.root+'/xmpls/SolarPanelReport.pdf'),
-      { headers: { 'Content-Type': 'application/pdf' }}
+      require('fs').createReadStream (filePath),
+      { headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Length': fileSize
+      }}
     )
     expect(uploaded.status).to.equal(204)
 


### PR DESCRIPTION
Test suite failed because an attachment was uploaded without Content-Length header. Missing Content-Length header leads to a 403 (Invalid Content Size) in the attachments plugin since the following change: https://github.com/cap-js/attachments/pull/105/files#diff-11af61311ab29f43ed180a25e84cbae6a92c72a244b8c4f717d573ec930ff5acR90-R103 