### PR TITLE
chore: fixing more package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "express": "^4"
   },
   "devDependencies": {
-    "@cap-js/cds-test": "^0",
-    "@cap-js/audit-logging": "^0.8.3",
+    "@cap-js/cds-test": "*",
+    "@cap-js/audit-logging": ">=0.8.3",
     "@cap-js/change-tracking": "^1.0.6",
     "@cap-js/attachments": "^2",
     "@cap-js/sqlite": ">=1"

--- a/xmpls/messaging/package.json
+++ b/xmpls/messaging/package.json
@@ -14,12 +14,11 @@
         "@sap/xb-msg-amqp-v100": "^0"
     },
     "devDependencies": {
-        "@cap-js/cds-test": "^0",
-        "@cap-js/sqlite": "^1.0.1",
-        "@sap/cds-dk": "^7",
+        "@cap-js/cds-test": "*",
+        "@cap-js/sqlite": "*",
+        "@sap/cds-dk": "*",
         "@sap/ux-specification": "^1.108.4",
-        "jest": "^29.5.0",
-        "rimraf": "^3.0.2"
+        "jest": "^29.5.0"
     },
     "scripts": {
         "watch": "cds watch",

--- a/xmpls/messaging/package.json
+++ b/xmpls/messaging/package.json
@@ -17,8 +17,7 @@
         "@cap-js/cds-test": "*",
         "@cap-js/sqlite": "*",
         "@sap/cds-dk": "*",
-        "@sap/ux-specification": "^1.108.4",
-        "jest": "^29.5.0"
+        "@sap/ux-specification": "^1.108.4"
     },
     "scripts": {
         "watch": "cds watch",

--- a/xmpls/remote-service/package.json
+++ b/xmpls/remote-service/package.json
@@ -9,15 +9,13 @@
         "@sap/cds": ">=7",
         "@sap/cds-hana": "^2",
         "@sap/xssec": "^3",
-        "express": "^4",
-        "passport": "^0"
+        "express": "^4"
     },
     "devDependencies": {
         "@cap-js/cds-test": "*",
         "@cap-js/sqlite": "*",
         "@sap/cds-dk": "*",
-        "@sap/ux-specification": "^1.108.4",
-        "jest": "^29.5.0"
+        "@sap/ux-specification": "^1.108.4"
     },
     "scripts": {
         "watch": "cds watch",

--- a/xmpls/remote-service/package.json
+++ b/xmpls/remote-service/package.json
@@ -13,12 +13,11 @@
         "passport": "^0"
     },
     "devDependencies": {
-        "@cap-js/cds-test": "^0",
-        "@cap-js/sqlite": "^1.0.1",
-        "@sap/cds-dk": "^7",
+        "@cap-js/cds-test": "*",
+        "@cap-js/sqlite": "*",
+        "@sap/cds-dk": "*",
         "@sap/ux-specification": "^1.108.4",
-        "jest": "^29.5.0",
-        "rimraf": "^3.0.2"
+        "jest": "^29.5.0"
     },
     "scripts": {
         "watch": "cds watch",


### PR DESCRIPTION
- never use `^0` dependencies (unless you really mean that)
- use `*` dependencies in package.jsons for nested/local test
- we always use `jest` via npx anyways
- `rimraf` shouldn't and seems to not be used any longer 