### PR TITLE
Notifications: use proper status code

### DIFF
--- a/xmpls/alert-notifications.js
+++ b/xmpls/alert-notifications.js
@@ -29,7 +29,7 @@ module.exports = class ProcessorService extends cds.ApplicationService {
      * Send a notification using a pre-defined template when an incident is resolved.
      */
     this.after ('UPDATE', Incidents, async incident => {
-      if (incident.status_code === 'C') {
+      if (incident.status_code === 'R') {
         let customer = await customer4 (incident)
         await alert.notify ('IncidentResolved', {
           recipients: [ customer.id ],


### PR DESCRIPTION
Comments and notification title suggest that a notification is sent when an incident is _resolved_. Status code for reolved is `R`, while `C` is closed.