### PR TITLE
Add node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@capire/incidents",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@sap/cds": ">=8",
     "express": "^4"


### PR DESCRIPTION
The deployment if the node version is not specified. If not specified, Node 18 is used.

![image](https://github.com/user-attachments/assets/802c701f-25f4-4052-8441-96dca0b7b785)
