### PR TITLE
don't patronize developers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
   "files.exclude": {
-    ".*": true,
-    "node_modules": true,
     "cds-plugin.js": true,
     "LICENSES": true,
     "REUSE*": true


### PR DESCRIPTION
If developers don't want to see node_modules or the .* files, they will have this set up in their development environment already. This is  a very frustrating setting, since this setting is essentially hiding itself, since it is in a folder with the pattern of .* so developers need to use a separate file explorer to actually find the cause of why their environment now behanves dfifferently. Either this, or make a *very bold* top-level caveat in the readme